### PR TITLE
Fix starship initialization

### DIFF
--- a/scripts/config/config.sh
+++ b/scripts/config/config.sh
@@ -34,7 +34,7 @@ if [ -z "$FASTFETCH_SHOWN" ]; then
 fi
 
 # Activar starship
-eval "$(starship init $SHELL)"
+eval "$(starship init $CURRENT_SHELL)"
 # GLITX_PROMPT_END
 EOF
 


### PR DESCRIPTION
## Summary
- fix starship init command to use the shell name rather than full path

## Testing
- `make` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_685e1ac61aa88323978dad7f58616ee2