### PR TITLE
Fix fastfetch setup instructions

### DIFF
--- a/scripts/fastfetch/setup.sh
+++ b/scripts/fastfetch/setup.sh
@@ -24,6 +24,5 @@ echo "📂 Instalando binario..."
 sudo make install
 
 echo "✅ fastfetch instalado correctamente."
+# Instruye al usuario a ejecutar fastfetch manualmente
 echo "👉 Puedes ejecutarlo con el comando: fastfetch"
-
-fastfetch


### PR DESCRIPTION
## Summary
- remove stray `fastfetch` execution
- keep instructions that tell users to run `fastfetch` manually

## Testing
- `bash -n scripts/fastfetch/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e2514bd0883238d2975bf9d785cff