### PR TITLE
Add Bats test for config script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,7 @@ echo 'eval "$(starship init bash)"' >> ~/.bashrc
 source ~/.bashrc
 @echo "========================="
 
+
+
+test:
+	bats tests

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMP_HOME="$(mktemp -d)"
+  export HOME="$TMP_HOME"
+  export SHELL="/bin/bash"
+  export PATH="$TMP_HOME/bin:$PATH"
+  mkdir -p "$TMP_HOME/bin"
+
+  cat <<'EOFF' > "$TMP_HOME/bin/starship"
+#!/bin/sh
+exit 0
+EOFF
+  chmod +x "$TMP_HOME/bin/starship"
+
+  cat <<'EOFF' > "$TMP_HOME/bin/fastfetch"
+#!/bin/sh
+exit 0
+EOFF
+  chmod +x "$TMP_HOME/bin/fastfetch"
+
+  touch "$HOME/.bashrc"
+}
+
+teardown() {
+  rm -rf "$TMP_HOME"
+}
+
+@test "config.sh appends GLITX_PROMPT block" {
+  run scripts/config/config.sh
+  [ "$status" -eq 0 ]
+  grep -q "# GLITX_PROMPT_BEGIN" "$HOME/.bashrc"
+  grep -q "# GLITX_PROMPT_END" "$HOME/.bashrc"
+}


### PR DESCRIPTION
## Summary
- add tests directory with Bats test for `scripts/config/config.sh`
- append a `test` target to run `bats tests` via Makefile

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e260ee01483238fc3de0b0f09f5ac